### PR TITLE
add ts output + support for sending threaded replies when posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,19 @@ GitHub Action that posts a message to a Slack channel
 
 **Required** The channel name to post to (example: `#general`)
 
+#### `thread_ts`
+
+**Optional** The timestamp ID of the parent message to reply to (e.g., the `ts` output from a previous Slack message call)
+
 ### `text`
 
 **Required** The message text to post
+
+## Outputs
+
+### `ts`
+
+The timestamp ID of the message (can be used to make subsequent Slack messages a threaded reply)
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
     - run: |
         {
           echo "ts=<<EOF"
-          curl --silent --show-error -X POST -H "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" -H "Content-Type: application/json" --url https://slack.com/api/chat.postMessage \
+          curl --silent --show-error -X POST -H "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" -H "Content-Type: application/json; charset=utf-8" --url https://slack.com/api/chat.postMessage \
             -d "{\"channel\": \"${{ inputs.channel }}\", \"thread_ts\":\"${{ inputs.thread_ts }}\", \"text\":\"${{ inputs.text }}\"}" \
             | jq --raw-output '.ts'
           echo "EOF"

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,16 @@ inputs:
     required: false
   channel:
     description: "The channel name to post to"
-    required: true    
+    required: true
+  thread_ts:
+    description: "The timestamp ID of the parent message to reply to"
+    required: false
   text:
     description: "The message text to post"
     required: true
+outputs:
+  ts:
+    description: "The timestamp ID of the message that was just posted"
 branding:
   icon: 'tag'
   color: 'blue'
@@ -17,6 +23,11 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        curl --silent --show-error -X POST -H "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" -H "Content-Type: application/json" --url https://slack.com/api/chat.postMessage \
-          -d "{\"channel\": \"${{ inputs.channel }}\", \"text\":\"${{ inputs.text }}\"}"
+        {
+          echo "ts=<<EOF"
+          curl --silent --show-error -X POST -H "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" -H "Content-Type: application/json" --url https://slack.com/api/chat.postMessage \
+            -d "{\"channel\": \"${{ inputs.channel }}\", \"thread_ts\":\"${{ inputs.thread_ts }}\", \"text\":\"${{ inputs.text }}\"}" \
+            | jq --raw-output '.ts'
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
### This PR:
- adds a `ts` output to this action that contains the "timestamp ID" of the message that was just posted (see https://api.slack.com/methods/chat.postMessage#examples)
- adds support for a new optional `thread_ts` input that, when set to the `ts` value of another message, will make the new message reply in a thread (see https://api.slack.com/methods/chat.postMessage#arg_thread_ts).
- :broom: explicitly sets `charset=utf-8` in the `Content-Type` header of the API request to silence a warning we've been getting back from Slack's API:
  - `"warning":"missing_charset"` (see https://api.slack.com/methods/chat.postMessage#warnings)

This change should be backward compatible since sending an empty string for `thread_ts` still functions as expected, so I assume we'll probably deploy this as version 1.2.

### Context

I'd like to make some deploy messages have additional detail, but instead of increasing the length of the main message, I'd like to play around with posting threaded replies.

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExeHVodnR4N2NoaTRxeG5kN255cTFsdWhvejRrNnN2ZjZscnpiMTB6MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2Sq4qm3ia1jo14Yg/giphy.webp)