### PR TITLE
add support for unfurl_links + better logging

### DIFF
--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -1,0 +1,31 @@
+name: Branch Builder
+
+on:
+    pull_request:
+      types: [opened, reopened, synchronize]
+    push:
+      branches: [ main ]
+      tags-ignore: "**"
+    workflow_dispatch:
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} # github.head_ref for pull_request event and github.ref_name for push event
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_TEST_TOKEN }}
+  SLACK_CHANNEL_ID: ${{ secrets.SLACK_TEST_CHANNEL_ID }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test Slack message with default settings
+        id: basic-message
+        uses: ./
+        with:
+          channel: ${{ env.SLACK_CHANNEL_ID }}
+          text: 'Test message from <https://github.com/${{ github.repository }}|`${{ github.repository }}`>:\n\nMessage sent from: <https://github.com/${{ github.repository }}/compare/main...${{ env.BRANCH_NAME }}|`${{ env.BRANCH_NAME }}`>\nWorkflow Log: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run ${{ github.run_id }}>'
+      - name: Test Slack message with optional inputs specified (reply message + unfurl_links disabled)
+        uses: ./
+        with:
+          channel: ${{ env.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ steps.basic-message.outputs.ts }}
+          text: 'Test reply with a link to unfurl (that should _not_ unfurl): <https://aus.youneedabudget.com/|YNAB AU Marketing Site>'
+          unfurl_links: false

--- a/action.yml
+++ b/action.yml
@@ -23,11 +23,17 @@ runs:
   using: 'composite'
   steps:
     - run: |
+        response=$(curl --fail-with-body --silent --show-error \
+          --request POST \
+          --header "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" \
+          --header "Content-Type: application/json; charset=utf-8" \
+          --url https://slack.com/api/chat.postMessage \
+          --data "{\"channel\": \"${{ inputs.channel }}\", \"thread_ts\": \"${{ inputs.thread_ts }}\", \"text\": \"${{ inputs.text }}\"}" \
+        )
+        echo "Slack API response:\n$response"
         {
-          echo "ts=<<EOF"
-          curl --silent --show-error -X POST -H "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" -H "Content-Type: application/json; charset=utf-8" --url https://slack.com/api/chat.postMessage \
-            -d "{\"channel\": \"${{ inputs.channel }}\", \"thread_ts\":\"${{ inputs.thread_ts }}\", \"text\":\"${{ inputs.text }}\"}" \
-            | jq --raw-output '.ts'
+          echo "ts<<EOF"
+          echo "$response" | jq --raw-output '.ts'
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -20,24 +20,30 @@ inputs:
 outputs:
   ts:
     description: "The timestamp ID of the message that was just posted"
+    value: ${{steps.slack-post-message.outputs.ts}}
 branding:
   icon: 'tag'
   color: 'blue'
 runs:
   using: 'composite'
   steps:
-    - shell: bash
+    - name: Validate required inputs
+      shell: bash
+      run: |
+        [[ "${{ inputs.channel }}" ]] || { echo "required input 'channel' not specified" ; exit 1; }
+        [[ "${{ inputs.text }}" ]] || { echo "required input 'text' not specified" ; exit 1; }
+    - name: POST to chat.postMessage API
+      id: slack-post-message
+      shell: bash
       run: |
         response=$(curl --fail-with-body --silent --show-error \
           --request POST \
           --header "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" \
           --header "Content-Type: application/json; charset=utf-8" \
           --url https://slack.com/api/chat.postMessage \
-          --data "{\"channel\": \"${{ inputs.channel }}\", \"thread_ts\": \"${{ inputs.thread_ts }}\", \"unfurl_links\": ${{ inputs.unfurl_links }}, \"text\": \"${{ inputs.text }}\"}" \
+          --data '{"channel": "${{ inputs.channel }}", "thread_ts": "${{ inputs.thread_ts }}", "unfurl_links": ${{ inputs.unfurl_links }}, "text": "${{ inputs.text }}"}' \
         )
-        echo "Slack API response:\n$response"
-        {
-          echo "ts<<EOF"
-          echo "$response" | jq --raw-output '.ts'
-          echo "EOF"
-        } >> "$GITHUB_OUTPUT"
+        echo "Slack message API response:\n$response"
+        ts=$(echo "$response" | jq --raw-output '.ts')
+        echo "Setting ts output to $ts"
+        echo "ts=$ts" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,8 @@ branding:
 runs:
   using: 'composite'
   steps:
-    - run: |
+    - shell: bash
+      run: |
         response=$(curl --fail-with-body --silent --show-error \
           --request POST \
           --header "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" \
@@ -40,4 +41,3 @@ runs:
           echo "$response" | jq --raw-output '.ts'
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   text:
     description: "The message text to post"
     required: true
+  unfurl_links:
+    description: "Whether links in the message should be unfurled"
+    type: boolean
+    default: true
 outputs:
   ts:
     description: "The timestamp ID of the message that was just posted"
@@ -28,7 +32,7 @@ runs:
           --header "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" \
           --header "Content-Type: application/json; charset=utf-8" \
           --url https://slack.com/api/chat.postMessage \
-          --data "{\"channel\": \"${{ inputs.channel }}\", \"thread_ts\": \"${{ inputs.thread_ts }}\", \"text\": \"${{ inputs.text }}\"}" \
+          --data "{\"channel\": \"${{ inputs.channel }}\", \"thread_ts\": \"${{ inputs.thread_ts }}\", \"unfurl_links\": ${{ inputs.unfurl_links }}, \"text\": \"${{ inputs.text }}\"}" \
         )
         echo "Slack API response:\n$response"
         {


### PR DESCRIPTION
- add support for optional `unfurl_links` argument (defaults to `true`, but can be used to disable link unfurling when desired)
- use `--fail-with-body` so HTTP status of >= 400 triggers an error exit code
- use long form curl args in general for better readability/comprehensibility
- break up curl args over multiple lines to improve readability
- log raw response before processing it
- fix how this action sets its `ts` output so that it actually works!
- adds a GH workflow to this repo to enable testing changes in PRs _before_ they're merged and without having to setup private, throw-away repos that use your branch of this GH action for testing

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGQ2Y29vanUwMWVnbmloNmd6cnUyaDhhMnJ4MWU1MDh4czBkNG93ZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VXCPgZwEP7f1e/giphy.webp)