### PR TITLE
action: use bash ansi c quoting for JSON args to curl

### DIFF
--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -29,3 +29,10 @@ jobs:
           thread_ts: ${{ steps.basic-message.outputs.ts }}
           text: 'Test reply with a link to unfurl (that should _not_ unfurl): <https://aus.youneedabudget.com/|YNAB AU Marketing Site>'
           unfurl_links: false
+      - name: Test Slack message with various text formatting
+        uses: ./
+        with:
+          channel: ${{ env.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ steps.basic-message.outputs.ts }}
+          text: "Test various text formatting:\n• Single quotes must be escaped \\' (b/c bash)\n• literal emoji 😀\n• colon-formatted emoji :blob-wave:\n• *bold text*\n• _italicized text_\n• ~strikethrough text~\n• `inline code`\n• Automatically linked text www.ynab.com\n• Link with <http://www.ynab.com|custom text>\n>Block quote\n```Multi-line\ncode```"
+          unfurl_links: false

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub Action that posts a message to a Slack channel
 
 ### `text`
 
-**Required** The message text to post
+**Required** The message text to post. See [Slack's documentation on formatting](https://api.slack.com/reference/surfaces/formatting#basic-formatting). Note that single quotes in your message *must* be escaped as `\'` due to how this input is consumed by bash.
 
 ### `unfurl_links`
 

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
           --header "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" \
           --header "Content-Type: application/json; charset=utf-8" \
           --url https://slack.com/api/chat.postMessage \
-          --data '{"channel": "${{ inputs.channel }}", "thread_ts": "${{ inputs.thread_ts }}", "unfurl_links": ${{ inputs.unfurl_links }}, "text": "${{ inputs.text }}"}' \
+          --data $'{"channel": "${{ inputs.channel }}", "thread_ts": "${{ inputs.thread_ts }}", "unfurl_links": ${{ inputs.unfurl_links }}, "text": "${{ inputs.text }}"}' \
         )
         echo "Slack message API response:\n$response"
         ts=$(echo "$response" | jq --raw-output '.ts')


### PR DESCRIPTION
This _should_ help avoid issues where various types of quotes in `inputs.text` could cause problems when inserted into the JSON string we're building.

Mashing strings together and pretending it's JSON is never going to be perfect, but this should be _more_ resilient than plain single quotes or double quotes.

https://linux.die.net/man/1/bash#:~:text=Words%20of%20the%20form%20%24%27string%27%20are%20treated%20specially.

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcjUyeHF3OXV6cnFka2x3bWoxMzlzNzJqMW44NHphbnRnbXc4cTAzNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/cmlRgl9ZlDp6C8zxjo/giphy.webp)