### PR TITLE
Use jq to build JSON payload instead of string interpolation

### DIFF
--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -36,3 +36,17 @@ jobs:
           thread_ts: ${{ steps.basic-message.outputs.ts }}
           text: "Test various text formatting:\n• Single quotes must be escaped \\' (b/c bash)\n• literal emoji 😀\n• colon-formatted emoji :blob-wave:\n• *bold text*\n• _italicized text_\n• ~strikethrough text~\n• `inline code`\n• Automatically linked text www.ynab.com\n• Link with <http://www.ynab.com|custom text>\n>Block quote\n```Multi-line\ncode```"
           unfurl_links: false
+      - name: Test Slack message with multiline text (literal newlines)
+        uses: ./
+        with:
+          channel: ${{ env.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ steps.basic-message.outputs.ts }}
+          text: |-
+            :rocket: *Test multiline message with literal newlines*
+
+            ───────────────────
+            :sparkles: *What's in this release:*
+            • Fixed transaction image overlay to display above the help widget
+            • Mobile apps now show bank institution names and logos
+            • Improved mobile app performance when loading budget data
+          unfurl_links: false

--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -7,10 +7,14 @@ on:
       branches: [ main ]
       tags-ignore: "**"
     workflow_dispatch:
+      inputs:
+        channel_override:
+          description: "Optional Slack channel/DM ID to post to instead of the default test channel"
+          required: false
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }} # github.head_ref for pull_request event and github.ref_name for push event
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_TEST_TOKEN }}
-  SLACK_CHANNEL_ID: ${{ secrets.SLACK_TEST_CHANNEL_ID }}
+  SLACK_CHANNEL_ID: ${{ github.event.inputs.channel_override || secrets.SLACK_TEST_CHANNEL_ID }}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Test Slack message with default settings
         id: basic-message
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ runs:
         INPUT_UNFURL_LINKS: ${{ inputs.unfurl_links }}
         INPUT_TEXT: ${{ inputs.text }}
       run: |
+        # Interpret escape sequences (e.g. \n) so jq encodes them correctly,
+        # preserving backwards compatibility with the old $'...' bash quoting.
+        INPUT_TEXT=$(printf '%b' "$INPUT_TEXT")
         payload=$(jq --null-input \
           --arg channel "$INPUT_CHANNEL" \
           --arg thread_ts "$INPUT_THREAD_TS" \

--- a/action.yml
+++ b/action.yml
@@ -35,13 +35,24 @@ runs:
     - name: POST to chat.postMessage API
       id: slack-post-message
       shell: bash
+      env:
+        INPUT_CHANNEL: ${{ inputs.channel }}
+        INPUT_THREAD_TS: ${{ inputs.thread_ts }}
+        INPUT_UNFURL_LINKS: ${{ inputs.unfurl_links }}
+        INPUT_TEXT: ${{ inputs.text }}
       run: |
+        payload=$(jq --null-input \
+          --arg channel "$INPUT_CHANNEL" \
+          --arg thread_ts "$INPUT_THREAD_TS" \
+          --argjson unfurl_links "$INPUT_UNFURL_LINKS" \
+          --arg text "$INPUT_TEXT" \
+          '{channel: $channel, thread_ts: $thread_ts, unfurl_links: $unfurl_links, text: $text}')
         response=$(curl --fail-with-body --silent --show-error \
           --request POST \
           --header "Authorization: Bearer ${{ env.SLACK_BOT_TOKEN || inputs.token }}" \
           --header "Content-Type: application/json; charset=utf-8" \
           --url https://slack.com/api/chat.postMessage \
-          --data $'{"channel": "${{ inputs.channel }}", "thread_ts": "${{ inputs.thread_ts }}", "unfurl_links": ${{ inputs.unfurl_links }}, "text": "${{ inputs.text }}"}' \
+          --data "$payload" \
         )
         echo "Slack message API response:\n$response"
         ts=$(echo "$response" | jq --raw-output '.ts')


### PR DESCRIPTION
The `$'...'` shell quoting in the curl `--data` argument breaks when `inputs.text` contains literal newlines. The shell splits the string across lines and tries to execute each subsequent line as a separate command:

```
curl: (6) Could not resolve host: in
curl: (6) Could not resolve host: this
•: command not found
```

This started happening after we added AI-generated release summaries to Evergreen's production deploy workflow — the summary is multiline with bullet points, which broke the Slack notification step.

The fix uses `jq` to construct the JSON payload, which properly escapes newlines, quotes, and any other special characters. Inputs are passed via `env` variables rather than direct `${{ }}` interpolation in the shell script to avoid the same class of injection issues.

### Backwards compatibility

The old `$'...'` quoting interpreted `\n` escape sequences as actual newlines. With `jq --arg`, literal `\n` (backslash + n) would be kept as-is and double-escaped in the JSON output, causing Slack to render the literal text `\n` instead of a line break. To preserve the old behavior, the fix uses `printf '%b'` to convert escape sequences to real characters before passing them to `jq`. This ensures callers using inline `\n` in single-quoted YAML strings (like the existing branch builder tests) still get newlines in Slack.

### Notes

- `jq` is already used later in this action to parse the API response, so no new dependency.
- #8 confirms the multiline test fails without this fix.

Failed run: https://github.com/ynab/evergreen/actions/runs/24044185166