### PR TITLE
Pin actions/checkout to commit SHA

### DIFF
--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Test Slack message with default settings
         id: basic-message
         uses: ./


### PR DESCRIPTION
Pin `actions/checkout@v4` to its commit SHA for supply chain security, consistent with how Evergreen pins all GitHub Actions to SHAs.