### PR TITLE
DO NOT MERGE: Prove multiline text fails without jq fix

### DIFF
--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -36,3 +36,17 @@ jobs:
           thread_ts: ${{ steps.basic-message.outputs.ts }}
           text: "Test various text formatting:\n• Single quotes must be escaped \\' (b/c bash)\n• literal emoji 😀\n• colon-formatted emoji :blob-wave:\n• *bold text*\n• _italicized text_\n• ~strikethrough text~\n• `inline code`\n• Automatically linked text www.ynab.com\n• Link with <http://www.ynab.com|custom text>\n>Block quote\n```Multi-line\ncode```"
           unfurl_links: false
+      - name: Test Slack message with multiline text (literal newlines)
+        uses: ./
+        with:
+          channel: ${{ env.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ steps.basic-message.outputs.ts }}
+          text: |-
+            :rocket: *Test multiline message with literal newlines*
+
+            ───────────────────
+            :sparkles: *What's in this release:*
+            • Fixed transaction image overlay to display above the help widget
+            • Mobile apps now show bank institution names and logos
+            • Improved mobile app performance when loading budget data
+          unfurl_links: false

--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Test Slack message with default settings
         id: basic-message
         uses: ./


### PR DESCRIPTION
Temporary PR to confirm the multiline test step fails without the action.yml fix from #6.

This branch adds only the multiline test — no fix. Expected result: the "Test Slack message with multiline text" step should fail with shell errors like `•: command not found`.

Close this after confirming the failure.