### PR TITLE
Fix multiline text breaking input validation

### DIFF
--- a/.github/workflows/branch-builder.yml
+++ b/.github/workflows/branch-builder.yml
@@ -54,3 +54,14 @@ jobs:
             • Mobile apps now show bank institution names and logos
             • Improved mobile app performance when loading budget data
           unfurl_links: false
+      - name: Test Slack message with multiline text containing double quotes
+        uses: ./
+        with:
+          channel: ${{ env.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ steps.basic-message.outputs.ts }}
+          text: |-
+            :rocket: *Test multiline with "quoted" text*
+
+            • Fixed a bug where the "assign money" prompt appeared too early
+            • Improved the "getting started" onboarding flow
+          unfurl_links: false

--- a/action.yml
+++ b/action.yml
@@ -29,9 +29,12 @@ runs:
   steps:
     - name: Validate required inputs
       shell: bash
+      env:
+        INPUT_CHANNEL: ${{ inputs.channel }}
+        INPUT_TEXT: ${{ inputs.text }}
       run: |
-        [[ "${{ inputs.channel }}" ]] || { echo "required input 'channel' not specified" ; exit 1; }
-        [[ "${{ inputs.text }}" ]] || { echo "required input 'text' not specified" ; exit 1; }
+        [[ "$INPUT_CHANNEL" ]] || { echo "required input 'channel' not specified"; exit 1; }
+        [[ "$INPUT_TEXT" ]] || { echo "required input 'text' not specified"; exit 1; }
     - name: POST to chat.postMessage API
       id: slack-post-message
       shell: bash


### PR DESCRIPTION
## Summary
- The validation step used direct `${{ inputs.text }}` interpolation inside a bash `[[ ]]` conditional. When the text contains double quotes (e.g. `the "assign money" prompt` from AI-generated release summaries), the `"` prematurely closes the bash string and causes `conditional binary operator expected`
- This is the same class of bug fixed in #6 for the curl step — passing inputs through `env` vars so bash handles the value safely regardless of content
- Added a regression test with embedded double quotes that reproduces the exact failure

### Verified
- **Unfixed (main + test):** [failed with `conditional binary operator expected`](https://github.com/ynab/slack-post-message-action/actions/runs/24098797848) — same error as the Evergreen deploy
- **Fixed (this PR):** [passed](https://github.com/ynab/slack-post-message-action/actions/runs/24098805602)

Failed Evergreen run: https://github.com/ynab/evergreen/actions/runs/24091086289/job/70277346897

## Test plan
- [x] New test with embedded double quotes fails on unfixed main
- [x] New test with embedded double quotes passes on this branch
- [x] Existing multiline test (literal newlines) still passes
- [x] Existing escaped `\n` test cases still render newlines correctly in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)